### PR TITLE
security(backend): add input validation, password complexity, securit…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,7 +5,7 @@ DATABASE_URL=postgresql://user:password@localhost:5432/portfolio
 SECRET_API_KEY=your-secret-key-here
 DEFAULT_USER=sergiopenagos
 DEFAULT_EMAIL=sergio@example.com
-DEFAULT_PASSWORD=changeme
+DEFAULT_PASSWORD=Ch@ngeMe1!  # Must have: 8+ chars, uppercase, lowercase, digit, special char
 
 # Project Types
 DEFAULT_PROJECT_TYPE_1=Job

--- a/backend/src/controllers/auth_controller.py
+++ b/backend/src/controllers/auth_controller.py
@@ -2,6 +2,7 @@ from flask import request, jsonify
 from services.auth_service import AuthService
 from repositories.user_repository import UserRepository
 from models.database import Session
+from utils.validators import validate_required_fields, validate_string_length, sanitize_dict
 
 
 session = Session()
@@ -11,13 +12,27 @@ user_repository = UserRepository(session)
 
 auth_service = AuthService(user_repository)
 
+STRING_FIELDS = ['username', 'password']
+
 def login():
     try:
         data = request.get_json()
-        username = data.get('username')
-        password = data.get('password')
 
-        token = auth_service.login(username, password)
+        valid, error = validate_required_fields(data, ['username', 'password'])
+        if not valid:
+            return jsonify({"message": error}), 400
+
+        data = sanitize_dict(data, STRING_FIELDS)
+
+        valid, error = validate_string_length(data['username'], 'Username', min_len=3, max_len=50)
+        if not valid:
+            return jsonify({"message": error}), 400
+
+        valid, error = validate_string_length(data['password'], 'Password', min_len=1, max_len=128)
+        if not valid:
+            return jsonify({"message": error}), 400
+
+        token = auth_service.login(data['username'], data['password'])
 
         if token:
             return jsonify({"message": "Login successful!", "token": token}), 200

--- a/backend/src/controllers/project_controller.py
+++ b/backend/src/controllers/project_controller.py
@@ -1,14 +1,68 @@
 from flask import request, jsonify
 from services.project_service import ProjectService
 from utils.auth_decorator import token_required
+from utils.validators import validate_required_fields, validate_string_length, validate_url, sanitize_dict
 
 project_service = ProjectService()
+
+STRING_FIELDS = ['name', 'description', 'link', 'responsibilities']
 
 
 @token_required
 def create_project(user_id):
 
     data = request.get_json()
+
+    valid, error = validate_required_fields(data, ['name', 'link', 'project_type_id', 'technologies', 'tags'])
+    if not valid:
+        return jsonify({"message": error}), 400
+
+    data = sanitize_dict(data, STRING_FIELDS)
+
+    valid, error = validate_string_length(data['name'], 'Project name', min_len=1, max_len=255)
+    if not valid:
+        return jsonify({"message": error}), 400
+
+    valid, error = validate_url(data['link'], 'Project link')
+    if not valid:
+        return jsonify({"message": error}), 400
+
+    if 'description' in data and data['description']:
+        valid, error = validate_string_length(data['description'], 'Description', max_len=2000)
+        if not valid:
+            return jsonify({"message": error}), 400
+
+    if 'responsibilities' in data and data['responsibilities']:
+        valid, error = validate_string_length(data['responsibilities'], 'Responsibilities', max_len=2000)
+        if not valid:
+            return jsonify({"message": error}), 400
+
+    if not isinstance(data.get('technologies'), list) or len(data['technologies']) == 0:
+        return jsonify({"message": "Technologies must be a non-empty list"}), 400
+
+    if not isinstance(data.get('tags'), list) or len(data['tags']) == 0:
+        return jsonify({"message": "Tags must be a non-empty list"}), 400
+
+    if 'images' in data:
+        if not isinstance(data['images'], list) or len(data['images']) == 0:
+            return jsonify({"message": "Images must be a non-empty list"}), 400
+        for img in data['images']:
+            if not isinstance(img, dict) or not img.get('url'):
+                return jsonify({"message": "Each image must have a 'url' field"}), 400
+            valid, error = validate_url(img['url'], 'Image URL')
+            if not valid:
+                return jsonify({"message": error}), 400
+
+    if 'videos' in data and data['videos']:
+        if not isinstance(data['videos'], list):
+            return jsonify({"message": "Videos must be a list"}), 400
+        for vid in data['videos']:
+            if not isinstance(vid, dict) or not vid.get('url'):
+                return jsonify({"message": "Each video must have a 'url' field"}), 400
+            valid, error = validate_url(vid['url'], 'Video URL')
+            if not valid:
+                return jsonify({"message": error}), 400
+
     data['user_id'] = user_id
     project = project_service.create_project(data)
     return jsonify({"message": "Project created successfully", "project": project}), 201

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -9,6 +9,7 @@ from flask_cors import CORS
 from models.database import Session
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from utils.validators import validate_password_complexity
 
 
 def create_default_user():
@@ -19,6 +20,12 @@ def create_default_user():
     DEFAULT_USER = os.getenv("DEFAULT_USER")
     DEFAULT_EMAIL = os.getenv("DEFAULT_EMAIL")
     if existing_user is None:
+        valid, error = validate_password_complexity(DEFAULT_PASSWORD)
+        if not valid:
+            print(f"[WARN] Default password does not meet complexity requirements: {error}")
+            print("[WARN] Skipping default user creation. Set a stronger DEFAULT_PASSWORD in .env")
+            return
+
         hashed_password = bcrypt.hashpw(f"{DEFAULT_PASSWORD}".encode('utf-8'), bcrypt.gensalt())
         new_user = User(username=f'{DEFAULT_USER}', password=hashed_password.decode('utf-8'), email=f"{DEFAULT_EMAIL}")
 
@@ -60,6 +67,17 @@ types_project_blueprint.route('/project-types', methods=['GET'])(project_type_co
 app.register_blueprint(auth_blueprint)
 app.register_blueprint(project_blueprint)
 app.register_blueprint(types_project_blueprint)
+
+
+@app.after_request
+def add_security_headers(response):
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['X-Frame-Options'] = 'DENY'
+    response.headers['X-XSS-Protection'] = '1; mode=block'
+    response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
+    response.headers['Content-Security-Policy'] = "default-src 'self'"
+    response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+    return response
 
 
 if __name__ == '__main__':

--- a/backend/src/utils/validators.py
+++ b/backend/src/utils/validators.py
@@ -1,0 +1,84 @@
+import re
+from urllib.parse import urlparse
+
+
+def validate_required_fields(data, required_fields):
+    if not data or not isinstance(data, dict):
+        return False, "Request body must be a JSON object"
+    missing = [f for f in required_fields if not data.get(f)]
+    if missing:
+        return False, f"Missing required fields: {', '.join(missing)}"
+    return True, None
+
+
+def validate_string_length(value, field_name, min_len=1, max_len=500):
+    if not isinstance(value, str):
+        return False, f"{field_name} must be a string"
+    value = value.strip()
+    if len(value) < min_len:
+        return False, f"{field_name} must be at least {min_len} character(s)"
+    if len(value) > max_len:
+        return False, f"{field_name} must not exceed {max_len} characters"
+    return True, None
+
+
+def validate_url(url, field_name="URL"):
+    if not isinstance(url, str):
+        return False, f"{field_name} must be a string"
+    try:
+        result = urlparse(url.strip())
+        if not result.scheme or not result.netloc:
+            return False, f"{field_name} must be a valid URL with scheme (http/https)"
+        if result.scheme not in ("http", "https"):
+            return False, f"{field_name} must use http or https"
+        return True, None
+    except Exception:
+        return False, f"{field_name} is not a valid URL"
+
+
+def validate_email(email):
+    if not isinstance(email, str):
+        return False, "Email must be a string"
+    pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+    if not re.match(pattern, email.strip()):
+        return False, "Invalid email format"
+    return True, None
+
+
+def validate_password_complexity(password):
+    if not isinstance(password, str):
+        return False, "Password must be a string"
+    if len(password) < 8:
+        return False, "Password must be at least 8 characters"
+    if len(password) > 128:
+        return False, "Password must not exceed 128 characters"
+    if not re.search(r'[A-Z]', password):
+        return False, "Password must contain at least one uppercase letter"
+    if not re.search(r'[a-z]', password):
+        return False, "Password must contain at least one lowercase letter"
+    if not re.search(r'[0-9]', password):
+        return False, "Password must contain at least one digit"
+    if not re.search(r'[!@#$%^&*(),.?":{}|<>]', password):
+        return False, "Password must contain at least one special character"
+    return True, None
+
+
+def sanitize_string(value):
+    if not isinstance(value, str):
+        return value
+    value = value.strip()
+    value = re.sub(r'<[^>]+>', '', value)
+    value = value.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+    return value
+
+
+def sanitize_dict(data, string_fields):
+    if not isinstance(data, dict):
+        return data
+    sanitized = {}
+    for key, value in data.items():
+        if key in string_fields and isinstance(value, str):
+            sanitized[key] = sanitize_string(value)
+        else:
+            sanitized[key] = value
+    return sanitized

--- a/docs/specs/SPEC-P02b-security-hardening.md
+++ b/docs/specs/SPEC-P02b-security-hardening.md
@@ -1,0 +1,108 @@
+# SPEC-P02b: Security Hardening — Input Validation, Password Complexity & Security Headers
+
+**Task ID:** JOR-02b
+**Type:** security
+**Priority:** High
+**Status:** Completed
+**Date:** 2026-08-19
+**Author:** Brokkr (AI Architect)
+**Approver:** Jör (Visionary)
+
+---
+
+## 1. Summary
+
+Add input validation, password complexity requirements, input sanitization, and security headers to all backend endpoints.
+
+---
+
+## 2. Changes Made
+
+### 2.1 Input Validation (`utils/validators.py`)
+
+New validation utility module with functions:
+
+| Function | Purpose |
+|----------|---------|
+| `validate_required_fields(data, fields)` | Check required JSON fields exist |
+| `validate_string_length(value, field, min, max)` | Enforce string length limits |
+| `validate_url(url, field)` | Validate URL format (http/https) |
+| `validate_email(email)` | Validate email format |
+| `validate_password_complexity(password)` | Enforce password rules |
+| `sanitize_string(value)` | Strip HTML tags, escape entities |
+| `sanitize_dict(data, fields)` | Sanitize multiple string fields |
+
+### 2.2 Login Endpoint (`auth_controller.py`)
+
+- Validate required fields: `username`, `password`
+- Sanitize inputs before processing
+- Validate username length (3–50 chars)
+- Validate password length (1–128 chars)
+
+### 2.3 Project Creation Endpoint (`project_controller.py`)
+
+- Validate required fields: `name`, `link`, `project_type_id`, `technologies`, `tags`
+- Sanitize string inputs: `name`, `description`, `link`, `responsibilities`
+- Validate project name length (1–255 chars)
+- Validate project link is valid URL
+- Validate description length (max 2000 chars)
+- Validate responsibilities length (max 2000 chars)
+- Validate technologies and tags are non-empty lists
+- Validate images list: each must have valid URL
+- Validate videos list: each must have valid URL
+
+### 2.4 Password Complexity (`main.py`)
+
+Default user creation now validates password meets requirements:
+- Minimum 8 characters, maximum 128
+- At least one uppercase letter
+- At least one lowercase letter
+- At least one digit
+- At least one special character (`!@#$%^&*(),.?":{}|<>`)
+- Skips user creation with warning if password doesn't meet requirements
+
+### 2.5 Security Headers (`main.py`)
+
+Added `@app.after_request` handler with headers:
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `X-Content-Type-Options` | `nosniff` | Prevent MIME type sniffing |
+| `X-Frame-Options` | `DENY` | Prevent clickjacking |
+| `X-XSS-Protection` | `1; mode=block` | XSS filter |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Force HTTPS |
+| `Content-Security-Policy` | `default-src 'self'` | Restrict resource loading |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Control referrer info |
+
+### 2.6 CSRF Protection
+
+**Not required** for this API. CSRF attacks target cookie-based authentication. This API uses JWT tokens sent via `Authorization` header, which browsers never send automatically. CSRF protection is inherently provided by the JWT pattern.
+
+---
+
+## 3. Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/src/utils/validators.py` | New — validation utility module |
+| `backend/src/controllers/auth_controller.py` | Added input validation and sanitization |
+| `backend/src/controllers/project_controller.py` | Added input validation and sanitization |
+| `backend/src/main.py` | Password complexity check + security headers |
+| `backend/.env.example` | Updated password example with complexity note |
+
+---
+
+## 4. Verification
+
+- Login with missing fields → 400 error with descriptive message
+- Login with short username → 400 error
+- Create project with missing fields → 400 error
+- Create project with invalid URL → 400 error
+- Create project with HTML in name → sanitized (tags stripped)
+- Default user with weak password → skipped with warning
+- All responses include security headers
+
+---
+
+*Spec Version: 1.0*
+*Last Updated: 2026-08-19*


### PR DESCRIPTION
…y headers

- Add utils/validators.py with validation and sanitization functions
- Validate login endpoint: required fields, string lengths
- Validate project creation: required fields, URLs, strings, lists
- Add password complexity check for default user creation (8+ chars, upper, lower, digit, special)
- Add security headers: CSP, HSTS, X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy
- CSRF not needed (JWT-based auth, not cookie-based)
- Update .env.example with password complexity note
- Add SPEC-P02b-security-hardening.md spec